### PR TITLE
added: redshift snapshot schedule

### DIFF
--- a/update/main.tf
+++ b/update/main.tf
@@ -89,3 +89,15 @@ resource "aws_redshift_parameter_group" "default-redshift-parameter-group" {
   }
 
 }
+
+resource "aws_redshift_snapshot_schedule" "default" {
+  identifier = "tf-redshift-snapshot-schedule"
+  definitions = [
+    "rate(4 hours)",
+  ]
+}
+
+resource "aws_redshift_snapshot_schedule_association" "default" {
+  cluster_identifier  = aws_redshift_cluster.redshift_cluster.id
+  schedule_identifier = aws_redshift_snapshot_schedule.default.id
+}


### PR DESCRIPTION
https://dicemusic.atlassian.net/browse/DATA-2172

Tested plan here: 
https://github.com/dicefm/terraformpds/pull/424/

```
  # aws_redshift_snapshot_schedule.default will be created
  + resource "aws_redshift_snapshot_schedule" "default" {
      + arn               = (known after apply)
      + definitions       = [
          + "rate(4 hours)",
        ]
      + force_destroy     = false
      + id                = (known after apply)
      + identifier        = "tf-redshift-snapshot-schedule"
      + identifier_prefix = (known after apply)
    }

  # aws_redshift_snapshot_schedule_association.default will be created
  + resource "aws_redshift_snapshot_schedule_association" "default" {
      + cluster_identifier  = "dev-redshift"
      + id                  = (known after apply)
      + schedule_identifier = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```